### PR TITLE
Multi tile colours

### DIFF
--- a/foobot.groovy
+++ b/foobot.groovy
@@ -46,8 +46,13 @@ metadata {
         
         multiAttributeTile(name:"pollution", type:"thermostat", width:6, height:4) {
             tileAttribute("device.pollution", key: "PRIMARY_CONTROL") {
-    			attributeState("default", label:'${currentValue}% GPI', unit:"%", icon:"st.Weather.weather13")
-  		}
+    			attributeState("default", label:'${currentValue}% GPI', unit:"%", icon:"st.Weather.weather13", backgroundColors:[
+                    [value: 24, color: "#1c71ff"],
+                    [value: 49, color: "#5c93ee"],
+                    [value: 74, color: "#ff4040"],
+                    [value: 100, color: "#d62d20"]
+                ])
+  			}
        // valueTile("pollution", "device.pollution", inactiveLabel: false, decoration: "flat") {
        //     state "default", label:'${currentValue}% GPI', unit:"%"
        		tileAttribute("thermostatOperatingState", key: "OPERATING_STATE") {

--- a/foobot.groovy
+++ b/foobot.groovy
@@ -43,8 +43,8 @@ metadata {
 
 	tiles (scale: 2){   
 
-        
-        multiAttributeTile(name:"pollution", type:"thermostat", width:6, height:4) {
+
+        multiAttributeTile(name:"pollution", type:"generic", width:6, height:4) {
             tileAttribute("device.pollution", key: "PRIMARY_CONTROL") {
     			attributeState("default", label:'${currentValue}% GPI', unit:"%", icon:"st.Weather.weather13", backgroundColors:[
                     [value: 24, color: "#1c71ff"],
@@ -55,12 +55,9 @@ metadata {
   			}
        // valueTile("pollution", "device.pollution", inactiveLabel: false, decoration: "flat") {
        //     state "default", label:'${currentValue}% GPI', unit:"%"
-       		tileAttribute("thermostatOperatingState", key: "OPERATING_STATE") {
-    			attributeState("great", backgroundColor:"#bc2323")
-  				attributeState("good", backgroundColor:"#bc2323")
-            	attributeState("fair", backgroundColor:"#ffa81e")
-                attributeState("poor", backgroundColor:"#44b621")
-       }
+       		tileAttribute("device.GPIState", key: "SECONDARY_CONTROL") {
+    			attributeState("default", label:'${currentValue}')
+			}
        }
         valueTile("co2", "device.co2", inactiveLabel: false, width: 2, height: 2, decoration: "flat") {
             state "default", label:'${currentValue} CO2 ppm', unit:"ppm"


### PR DESCRIPTION
I love that I can monitor the foobot in smarthings, so kudos for making this :1st_place_medal:  I hope you're accepting pull requests.

I made a few tweaks to the main tile at the top. I added the label - great, good, fair & poor. I also coloured the background to closer match the colour of the foobot. Well kinda, I went close with.

* Poor - red
* fair - orange
* good - light blue
* great - darker blue

It's quite nice as the colour shows in the list view of the app too.